### PR TITLE
Add more info about current location

### DIFF
--- a/geo/src/androidMain/kotlin/dev/icerock/moko/geo/LocationTracker.kt
+++ b/geo/src/androidMain/kotlin/dev/icerock/moko/geo/LocationTracker.kt
@@ -5,6 +5,7 @@
 package dev.icerock.moko.geo
 
 import android.content.Context
+import android.os.Build
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
@@ -36,6 +37,7 @@ actual class LocationTracker(
         it.priority = priority
     }
     private val locationsChannel = Channel<LatLng>(Channel.BUFFERED)
+    private val extendedLocationsChannel = Channel<ExtendedLocation>(Channel.BUFFERED)
     private val trackerScope = CoroutineScope(Dispatchers.Main)
 
     fun bind(lifecycle: Lifecycle, context: Context, fragmentManager: FragmentManager) {
@@ -59,11 +61,51 @@ actual class LocationTracker(
     override fun onLocationResult(locationResult: LocationResult) {
         super.onLocationResult(locationResult)
 
+        val lastLocation = locationResult.lastLocation
+
+        val speedAccuracy = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) .0
+        else lastLocation.speedAccuracyMetersPerSecond.toDouble()
+
+        val bearingAccuracy = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) .0
+        else lastLocation.bearingAccuracyDegrees.toDouble()
+
+        val verticalAccuracy = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) .0
+        else lastLocation.verticalAccuracyMeters.toDouble()
+
         val latLng = LatLng(
-            locationResult.lastLocation.latitude,
-            locationResult.lastLocation.longitude
+            lastLocation.latitude,
+            lastLocation.longitude
         )
 
+        val locationPoint = Location(
+            coordinates = latLng,
+            coordinatesAccuracyMeters = lastLocation.accuracy.toDouble()
+        )
+
+        val speed = Speed(
+            lastLocation.speed.toDouble(),
+            speedAccuracy
+        )
+
+        val azimuth = Azimuth(
+            lastLocation.bearing.toDouble(),
+            bearingAccuracy
+        )
+
+        val altitude = Altitude(
+            lastLocation.altitude,
+            verticalAccuracy
+        )
+
+        val extendedLocation = ExtendedLocation(
+            location = locationPoint,
+            azimuth = azimuth,
+            speed = speed,
+            altitude = altitude,
+            timestampMs = lastLocation.time
+        )
+
+        trackerScope.launch { extendedLocationsChannel.send(extendedLocation) }
         trackerScope.launch { locationsChannel.send(latLng) }
     }
 
@@ -87,6 +129,20 @@ actual class LocationTracker(
                 while (isActive) {
                     val latLng = locationsChannel.receive()
                     sendChannel.send(latLng)
+                }
+            }
+
+            awaitClose { job.cancel() }
+        }
+    }
+
+    actual fun getExtendedLocationsFlow(): Flow<ExtendedLocation> {
+        return channelFlow {
+            val sendChannel = channel
+            val job = launch {
+                while (isActive) {
+                    val extendedLocation = extendedLocationsChannel.receive()
+                    sendChannel.send(extendedLocation)
                 }
             }
 

--- a/geo/src/androidMain/kotlin/dev/icerock/moko/geo/LocationTracker.kt
+++ b/geo/src/androidMain/kotlin/dev/icerock/moko/geo/LocationTracker.kt
@@ -63,13 +63,13 @@ actual class LocationTracker(
 
         val lastLocation = locationResult.lastLocation
 
-        val speedAccuracy = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) .0
+        val speedAccuracy = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) null
         else lastLocation.speedAccuracyMetersPerSecond.toDouble()
 
-        val bearingAccuracy = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) .0
+        val bearingAccuracy = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) null
         else lastLocation.bearingAccuracyDegrees.toDouble()
 
-        val verticalAccuracy = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) .0
+        val verticalAccuracy = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) null
         else lastLocation.verticalAccuracyMeters.toDouble()
 
         val latLng = LatLng(
@@ -83,18 +83,18 @@ actual class LocationTracker(
         )
 
         val speed = Speed(
-            lastLocation.speed.toDouble(),
-            speedAccuracy
+            speedMps = lastLocation.speed.toDouble(),
+            speedAccuracyMps = speedAccuracy
         )
 
         val azimuth = Azimuth(
-            lastLocation.bearing.toDouble(),
-            bearingAccuracy
+            azimuthDegrees = lastLocation.bearing.toDouble(),
+            azimuthAccuracyDegrees = bearingAccuracy
         )
 
         val altitude = Altitude(
-            lastLocation.altitude,
-            verticalAccuracy
+            altitudeMeters = lastLocation.altitude,
+            altitudeAccuracyMeters = verticalAccuracy
         )
 
         val extendedLocation = ExtendedLocation(
@@ -105,8 +105,10 @@ actual class LocationTracker(
             timestampMs = lastLocation.time
         )
 
-        trackerScope.launch { extendedLocationsChannel.send(extendedLocation) }
-        trackerScope.launch { locationsChannel.send(latLng) }
+        trackerScope.launch {
+            extendedLocationsChannel.send(extendedLocation)
+            locationsChannel.send(latLng)
+        }
     }
 
     actual suspend fun startTracking() {

--- a/geo/src/commonMain/kotlin/dev/icerock/moko/geo/Altitude.kt
+++ b/geo/src/commonMain/kotlin/dev/icerock/moko/geo/Altitude.kt
@@ -1,0 +1,10 @@
+package dev.icerock.moko.geo
+
+import dev.icerock.moko.parcelize.Parcelable
+import dev.icerock.moko.parcelize.Parcelize
+
+@Parcelize
+data class Altitude(
+    val altitudeMeters: Double,
+    val altitudeAccuracyMeters: Double
+) : Parcelable

--- a/geo/src/commonMain/kotlin/dev/icerock/moko/geo/Altitude.kt
+++ b/geo/src/commonMain/kotlin/dev/icerock/moko/geo/Altitude.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2021 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package dev.icerock.moko.geo
 
 import dev.icerock.moko.parcelize.Parcelable
@@ -6,5 +10,5 @@ import dev.icerock.moko.parcelize.Parcelize
 @Parcelize
 data class Altitude(
     val altitudeMeters: Double,
-    val altitudeAccuracyMeters: Double
+    val altitudeAccuracyMeters: Double?
 ) : Parcelable

--- a/geo/src/commonMain/kotlin/dev/icerock/moko/geo/Azimuth.kt
+++ b/geo/src/commonMain/kotlin/dev/icerock/moko/geo/Azimuth.kt
@@ -1,0 +1,10 @@
+package dev.icerock.moko.geo
+
+import dev.icerock.moko.parcelize.Parcelable
+import dev.icerock.moko.parcelize.Parcelize
+
+@Parcelize
+data class Azimuth(
+    val azimuthDegrees: Double,
+    val azimuthAccuracyDegrees: Double
+) : Parcelable

--- a/geo/src/commonMain/kotlin/dev/icerock/moko/geo/Azimuth.kt
+++ b/geo/src/commonMain/kotlin/dev/icerock/moko/geo/Azimuth.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2021 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package dev.icerock.moko.geo
 
 import dev.icerock.moko.parcelize.Parcelable
@@ -6,5 +10,5 @@ import dev.icerock.moko.parcelize.Parcelize
 @Parcelize
 data class Azimuth(
     val azimuthDegrees: Double,
-    val azimuthAccuracyDegrees: Double
+    val azimuthAccuracyDegrees: Double?
 ) : Parcelable

--- a/geo/src/commonMain/kotlin/dev/icerock/moko/geo/ExtendedLocation.kt
+++ b/geo/src/commonMain/kotlin/dev/icerock/moko/geo/ExtendedLocation.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2021 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package dev.icerock.moko.geo
 
 import dev.icerock.moko.parcelize.Parcelable

--- a/geo/src/commonMain/kotlin/dev/icerock/moko/geo/ExtendedLocation.kt
+++ b/geo/src/commonMain/kotlin/dev/icerock/moko/geo/ExtendedLocation.kt
@@ -1,0 +1,13 @@
+package dev.icerock.moko.geo
+
+import dev.icerock.moko.parcelize.Parcelable
+import dev.icerock.moko.parcelize.Parcelize
+
+@Parcelize
+data class ExtendedLocation(
+    val location: Location,
+    val azimuth: Azimuth,
+    val speed: Speed,
+    val altitude: Altitude,
+    val timestampMs: Long
+) : Parcelable

--- a/geo/src/commonMain/kotlin/dev/icerock/moko/geo/Location.kt
+++ b/geo/src/commonMain/kotlin/dev/icerock/moko/geo/Location.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2021 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package dev.icerock.moko.geo
 
 import dev.icerock.moko.parcelize.Parcelable

--- a/geo/src/commonMain/kotlin/dev/icerock/moko/geo/Location.kt
+++ b/geo/src/commonMain/kotlin/dev/icerock/moko/geo/Location.kt
@@ -1,0 +1,10 @@
+package dev.icerock.moko.geo
+
+import dev.icerock.moko.parcelize.Parcelable
+import dev.icerock.moko.parcelize.Parcelize
+
+@Parcelize
+class Location(
+    val coordinates: LatLng,
+    val coordinatesAccuracyMeters: Double
+) : Parcelable

--- a/geo/src/commonMain/kotlin/dev/icerock/moko/geo/LocationTracker.kt
+++ b/geo/src/commonMain/kotlin/dev/icerock/moko/geo/LocationTracker.kt
@@ -14,4 +14,6 @@ expect class LocationTracker {
     fun stopTracking()
 
     fun getLocationsFlow(): Flow<LatLng>
+
+    fun getExtendedLocationsFlow(): Flow<ExtendedLocation>
 }

--- a/geo/src/commonMain/kotlin/dev/icerock/moko/geo/Speed.kt
+++ b/geo/src/commonMain/kotlin/dev/icerock/moko/geo/Speed.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2021 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package dev.icerock.moko.geo
 
 import dev.icerock.moko.parcelize.Parcelable
@@ -6,5 +10,5 @@ import dev.icerock.moko.parcelize.Parcelize
 @Parcelize
 data class Speed(
     val speedMps: Double,
-    val speedAccuracyMps: Double
+    val speedAccuracyMps: Double?
 ) : Parcelable

--- a/geo/src/commonMain/kotlin/dev/icerock/moko/geo/Speed.kt
+++ b/geo/src/commonMain/kotlin/dev/icerock/moko/geo/Speed.kt
@@ -1,0 +1,10 @@
+package dev.icerock.moko.geo
+
+import dev.icerock.moko.parcelize.Parcelable
+import dev.icerock.moko.parcelize.Parcelize
+
+@Parcelize
+data class Speed(
+    val speedMps: Double,
+    val speedAccuracyMps: Double
+) : Parcelable

--- a/geo/src/iosMain/kotlin/dev/icerock/moko/geo/Tracker.kt
+++ b/geo/src/iosMain/kotlin/dev/icerock/moko/geo/Tracker.kt
@@ -11,5 +11,6 @@ import platform.darwin.NSObject
 
 internal expect class Tracker(
     locationsChannel: Channel<LatLng>,
+    extendedLocationsChannel: Channel<ExtendedLocation>,
     scope: CoroutineScope
 ) : NSObject, CLLocationManagerDelegateProtocol

--- a/geo/src/iosX64Main/kotlin/dev/icerock/moko/geo/Tracker.kt
+++ b/geo/src/iosX64Main/kotlin/dev/icerock/moko/geo/Tracker.kt
@@ -13,28 +13,66 @@ import platform.CoreLocation.CLLocationManager
 import platform.CoreLocation.CLLocationManagerDelegateProtocol
 import platform.Foundation.NSError
 import platform.Foundation.NSLog
+import platform.Foundation.timeIntervalSince1970
+import platform.UIKit.UIDevice
 import platform.darwin.NSObject
 import kotlin.native.ref.WeakReference
 
 internal actual class Tracker actual constructor(
     locationsChannel: Channel<LatLng>,
+    extendedLocationsChannel: Channel<ExtendedLocation>,
     scope: CoroutineScope
 ) : NSObject(), CLLocationManagerDelegateProtocol {
     private val coroutineScope = WeakReference(scope)
     private val locationsChannel = WeakReference(locationsChannel)
+    private val extendedLocationsChannel = WeakReference(extendedLocationsChannel)
 
     override fun locationManager(manager: CLLocationManager, didUpdateLocations: List<*>) {
         val locations = didUpdateLocations as List<CLLocation>
         val trackerScope = coroutineScope.get() ?: return
         val locationsChannel = locationsChannel.get() ?: return
+        val extendedLocationsChannel = extendedLocationsChannel.get() ?: return
 
         locations.forEach { location ->
+            val courseAccuracy = if (UIDevice.currentDevice.systemVersion.compareTo("13.4") < 0) .0
+            else location.courseAccuracy
+
             val latLng = location.coordinate().useContents {
                 LatLng(
                     latitude = latitude,
                     longitude = longitude
                 )
             }
+
+            val locationPoint = Location(
+                coordinates = latLng,
+                coordinatesAccuracyMeters = location.horizontalAccuracy
+            )
+
+            val speed = Speed(
+                speedMps = location.speed,
+                speedAccuracyMps = location.speedAccuracy
+            )
+
+            val azimuth = Azimuth(
+                azimuthDegrees = location.course,
+                azimuthAccuracyDegrees = courseAccuracy
+            )
+
+            val altitude = Altitude(
+                altitudeMeters = location.altitude,
+                altitudeAccuracyMeters = location.verticalAccuracy
+            )
+
+            val extendedLocation = ExtendedLocation(
+                location = locationPoint,
+                azimuth = azimuth,
+                speed = speed,
+                altitude = altitude,
+                timestampMs = location.timestamp.timeIntervalSince1970.toLong() * 1000
+            )
+
+            trackerScope.launch { extendedLocationsChannel.send(extendedLocation) }
             trackerScope.launch { locationsChannel.send(latLng) }
         }
     }

--- a/geo/src/iosX64Main/kotlin/dev/icerock/moko/geo/Tracker.kt
+++ b/geo/src/iosX64Main/kotlin/dev/icerock/moko/geo/Tracker.kt
@@ -34,7 +34,7 @@ internal actual class Tracker actual constructor(
         val extendedLocationsChannel = extendedLocationsChannel.get() ?: return
 
         locations.forEach { location ->
-            val courseAccuracy = if (UIDevice.currentDevice.systemVersion.compareTo("13.4") < 0) .0
+            val courseAccuracy = if (UIDevice.currentDevice.systemVersion.compareTo("13.4") < 0) null
             else location.courseAccuracy
 
             val latLng = location.coordinate().useContents {
@@ -72,8 +72,10 @@ internal actual class Tracker actual constructor(
                 timestampMs = location.timestamp.timeIntervalSince1970.toLong() * 1000
             )
 
-            trackerScope.launch { extendedLocationsChannel.send(extendedLocation) }
-            trackerScope.launch { locationsChannel.send(latLng) }
+            trackerScope.launch {
+                extendedLocationsChannel.send(extendedLocation)
+                locationsChannel.send(latLng)
+            }
         }
     }
 

--- a/sample/android-app/src/main/res/layout/activity_main.xml
+++ b/sample/android-app/src/main/res/layout/activity_main.xml
@@ -19,7 +19,13 @@
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@{viewModel.text.ld}" />
+            android:text="@{viewModel.textLocation.ld}" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@{viewModel.textExtendedLocation.ld}" />
 
         <Button
             android:layout_width="match_parent"

--- a/sample/ios-app/src/Resources/Base.lproj/Main.storyboard
+++ b/sample/ios-app/src/Resources/Base.lproj/Main.storyboard
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="yk9-44-Bpf">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="yk9-44-Bpf">
     <device id="retina4_0" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -24,41 +26,56 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Cj1-Xj-U8m">
-                                <rect key="frame" x="16" y="36.5" width="288" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Cj1-Xj-U8m">
+                                <rect key="frame" x="16" y="65" width="288" height="30"/>
                                 <state key="normal" title="start"/>
                                 <connections>
                                     <action selector="onStartPressed" destination="yk9-44-Bpf" eventType="touchUpInside" id="lju-xA-a1e"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ceD-AZ-c87">
-                                <rect key="frame" x="16" y="74.5" width="288" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ceD-AZ-c87">
+                                <rect key="frame" x="16" y="103" width="288" height="30"/>
                                 <state key="normal" title="stop"/>
                                 <connections>
                                     <action selector="onStopPressed" destination="yk9-44-Bpf" eventType="touchUpInside" id="3XJ-75-DqO"/>
                                 </connections>
                             </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SoO-eg-DpT">
+                                <rect key="frame" x="16" y="36.5" width="288" height="20.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="ceD-AZ-c87" firstAttribute="top" secondItem="Cj1-Xj-U8m" secondAttribute="bottom" constant="8" id="8HT-Lf-aBc"/>
                             <constraint firstItem="Mr6-Pm-lXM" firstAttribute="leading" secondItem="zse-rN-qv2" secondAttribute="leadingMargin" id="8gC-OK-JbB"/>
                             <constraint firstAttribute="trailingMargin" secondItem="Mr6-Pm-lXM" secondAttribute="trailing" id="Cj5-4s-Vz5"/>
                             <constraint firstItem="ceD-AZ-c87" firstAttribute="leading" secondItem="zse-rN-qv2" secondAttribute="leadingMargin" id="Ma0-5e-Obo"/>
                             <constraint firstAttribute="trailingMargin" secondItem="ceD-AZ-c87" secondAttribute="trailing" id="R8K-eP-Rj3"/>
+                            <constraint firstItem="SoO-eg-DpT" firstAttribute="top" secondItem="Mr6-Pm-lXM" secondAttribute="bottom" constant="8" id="U2e-rz-1Es"/>
                             <constraint firstItem="Cj1-Xj-U8m" firstAttribute="leading" secondItem="zse-rN-qv2" secondAttribute="leadingMargin" id="Wad-ch-OSk"/>
                             <constraint firstItem="Mr6-Pm-lXM" firstAttribute="top" secondItem="EjS-ay-zmX" secondAttribute="bottom" constant="8" symbolic="YES" id="eOY-q6-JoD"/>
+                            <constraint firstItem="Cj1-Xj-U8m" firstAttribute="top" secondItem="SoO-eg-DpT" secondAttribute="bottom" constant="8" id="jSN-J3-Val"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="SoO-eg-DpT" secondAttribute="trailing" id="n7Q-ES-Wce"/>
                             <constraint firstAttribute="trailingMargin" secondItem="Cj1-Xj-U8m" secondAttribute="trailing" id="qTQ-db-pH9"/>
-                            <constraint firstItem="Cj1-Xj-U8m" firstAttribute="top" secondItem="Mr6-Pm-lXM" secondAttribute="bottom" constant="8" id="rpY-eN-YwB"/>
+                            <constraint firstItem="SoO-eg-DpT" firstAttribute="leading" secondItem="zse-rN-qv2" secondAttribute="leadingMargin" id="uCq-mX-bbX"/>
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="textLabel" destination="Mr6-Pm-lXM" id="s9r-EX-ztn"/>
+                        <outlet property="textExtendedLocationLabel" destination="SoO-eg-DpT" id="huY-2V-dZo"/>
+                        <outlet property="textLocationLabel" destination="Mr6-Pm-lXM" id="s9r-EX-ztn"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="454-Cg-jr2" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-5625" y="-845"/>
+            <point key="canvasLocation" x="-5625" y="-845.07042253521126"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/sample/ios-app/src/TestViewController.swift
+++ b/sample/ios-app/src/TestViewController.swift
@@ -7,8 +7,9 @@ import MultiPlatformLibrary
 import CoreLocation
 
 class TestViewController: UIViewController {
-    @IBOutlet var textLabel: UILabel!
-    
+    @IBOutlet var textLocationLabel: UILabel!
+    @IBOutlet var textExtendedLocationLabel: UILabel!
+
     private var viewModel: TrackerViewModel!
     
     override func viewDidLoad() {
@@ -21,8 +22,12 @@ class TestViewController: UIViewController {
             )
         )
         
-        viewModel.text.addObserver { [weak self] text in
-            self?.textLabel.text = text as String?
+        viewModel.textLocation.addObserver { [weak self] text in
+            self?.textLocationLabel.text = text as String?
+        }
+        
+        viewModel.textExtendedLocation.addObserver { [weak self] text in
+            self?.textExtendedLocationLabel.text = text as String?
         }
     }
     


### PR DESCRIPTION
I added some new fields to location report such as azimuth, altitude, speed and timestamp. 

There are some differences in reported values between iOS and Android. For example, accuracy values on iOS can be negative according to https://developer.apple.com/documentation/corelocation/cllocation/1423599-horizontalaccuracy. On the other hand they can't be negative on Android. For now I don't really know if this case should be covered by library itself.

For backward compatibility I decided to add separate flow and container for extended location reports.