### PR TITLE
Allow coarse location

### DIFF
--- a/geo/src/androidMain/kotlin/dev/icerock/moko/geo/LocationTracker.kt
+++ b/geo/src/androidMain/kotlin/dev/icerock/moko/geo/LocationTracker.kt
@@ -115,8 +115,12 @@ actual class LocationTracker(
     }
 
     @SuppressLint("MissingPermission")
-    actual suspend fun startTracking() {
-        permissionsController.providePermission(Permission.LOCATION)
+    actual suspend fun startTracking(allowCoarseLocation: Boolean) {
+        val permission = when {
+            allowCoarseLocation -> Permission.COARSE_LOCATION
+            else -> Permission.LOCATION
+        }
+        permissionsController.providePermission(permission)
         // if permissions request failed - execution stops here
 
         isStarted = true

--- a/geo/src/commonMain/kotlin/dev/icerock/moko/geo/LocationTracker.kt
+++ b/geo/src/commonMain/kotlin/dev/icerock/moko/geo/LocationTracker.kt
@@ -10,7 +10,9 @@ import kotlinx.coroutines.flow.Flow
 expect class LocationTracker {
     val permissionsController: PermissionsController
 
-    suspend fun startTracking() // can be suspended for request permission
+    // can be suspended for request permission
+    suspend fun startTracking(allowCoarseLocation: Boolean = false)
+
     fun stopTracking()
 
     fun getLocationsFlow(): Flow<LatLng>

--- a/geo/src/iosMain/kotlin/dev/icerock/moko/geo/LocationTracker.kt
+++ b/geo/src/iosMain/kotlin/dev/icerock/moko/geo/LocationTracker.kt
@@ -35,8 +35,12 @@ actual class LocationTracker(
         desiredAccuracy = accuracy
     }
 
-    actual suspend fun startTracking() {
-        permissionsController.providePermission(Permission.LOCATION)
+    actual suspend fun startTracking(allowCoarseLocation: Boolean) {
+        val permission = when {
+            allowCoarseLocation -> Permission.COARSE_LOCATION
+            else -> Permission.LOCATION
+        }
+        permissionsController.providePermission(permission)
         // if permissions request failed - execution stops here
 
         locationManager.startUpdatingLocation()


### PR DESCRIPTION
Hi guys, firstly, thanks for this library, it's very helpful for me!

However, one thing that was bothering me is that you always ask for `Permission.LOCATION` and there is no ability to work with coarse location.

This is especially bad since on newer android versions, user is always presented with an option to only allow coarse location. This could lead to a scenario when you call `startTracking`, user selects coarse location, thinking location features will start working, but they won't. And only next time you call `startTracking`, user is presented with another dialog to change location access from approximate to precise.

I've added an option to `allowCoarseLocation` with default value `false`, so it should be a non-breaking change. However, I really believe that `true` should be the default in the future, because of the aforementioned behavior.